### PR TITLE
Fix pip Environment Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In this repo, we release:
 To get started, create a conda environment containing the required dependencies.
 
 ```bash
-conda env create -n duo
+conda env create -n duo python=3.9
 conda activate duo
 conda install nvidia/label/cuda-12.4.0::cuda-toolkit
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ rich==13.7.1
 seaborn==0.13.2
 scikit-learn==1.4.0
 transformers==4.38.2
-triton==2.2.0
+triton==2.3.1
 torch==2.3.1
 torchaudio==2.3.1
 torchmetrics==1.6.1


### PR DESCRIPTION
Hi, while install the environment, I found there're some depedency issue. Torch 2.3.1 cannot depend on Pyhton 3.13, which is the latest stable version. Also, Triton 2.2.0 is not compatible to Torch 2.3.1. PIP suggests Triton 2.3.1 for Torch 2.3.1 Please take a look at the modification. Thank you~
![Screenshot 2025-04-29 at 11 53 33 AM](https://github.com/user-attachments/assets/76f7a7ab-db82-4ba1-9587-9fe01e0c6ac6)
<img width="1106" alt="Screenshot 2025-04-28 at 12 13 05 PM" src="https://github.com/user-attachments/assets/bcedf359-7964-4a80-8c4d-e5abed157543" />
